### PR TITLE
.github/workflows: Use fetch-depth: 0 checkout in hashicorp workflow

### DIFF
--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -58,6 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Allow tag to be fetched when ref is a commit
+          fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ inputs.setup-go-version }}


### PR DESCRIPTION
When a calling workflow references a commit, it can cause `goreleaser` to not find the tag:

```
No tag found for commit 'xxxxxxx'. Snapshot forced
```