### PR TITLE
hashicorp: Update signore signer

### DIFF
--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -25,7 +25,7 @@ on:
         type: string
       signore-signer:
         description: 'signore Signer'
-        default: 'interim_signing_subkey_7685B676'
+        default: 'signing_subkey_CD27AB87'
         required: false
         type: string
     secrets:


### PR DESCRIPTION
The previous signer, `interim_signing_subkey_7685B676`, was transparently updated to use the same underlying key, except now it will now show a deprecation warning. Updates the signer so there is no deprecation warning or confusion about which key is being used.