### PR TITLE
.github: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hashicorp/terraform-provider-devex


### PR DESCRIPTION
Reference: https://github.com/orgs/hashicorp/teams/terraform-provider-devex
Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners