### PR TITLE
community: Switch to upstream ghaction-import-gpg action

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -33,10 +33,10 @@ jobs:
           go-version: ${{ inputs.setup-go-version }}
       - name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.gpg-private-key }}
-          PASSPHRASE: ${{ secrets.gpg-private-key-passphrase }}
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.gpg-private-key }}
+          passphrase: ${{ secrets.gpg-private-key-passphrase }}
       - if: inputs.release-notes != true
         name: goreleaser release (without release notes)
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
Reference: https://github.com/hashicorp/ghaction-import-gpg/issues/11

The GitHub hosted runners are now running `gpg-agent` by default, which can cause the following error:

```text
Run hashicorp/ghaction-import-gpg@v2.1.0
Run gpg-agent --daemon --default-cache-ttl 7200
gpg-agent[1632]: directory '/home/runner/.gnupg' created
gpg-agent[1632]: directory '/home/runner/.gnupg/private-keys-v1.d' created
gpg-agent: a gpg-agent is already running - not starting a new one
Error: Process completed with exit code 2.
```

The `hashicorp` fork of the `ghaction-import-gpg` action is not maintained and the recommendation is to switch to the upstream action.