### PR TITLE
Add workflows for generating release notes

### DIFF
--- a/.github/workflows/generate-release-notes-v1.yml
+++ b/.github/workflows/generate-release-notes-v1.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # Allow tag to be fetched when ref is a commit
+          fetch-depth: 0
       - name: Generate Release Notes
         # This sed command
         # - Removes the first line of CHANGELOG.md if it contains a # character

--- a/.github/workflows/generate-release-notes-v1.yml
+++ b/.github/workflows/generate-release-notes-v1.yml
@@ -1,0 +1,19 @@
+on:
+  workflow_call:
+
+jobs:
+  generate-release-notes:
+      - name: Generate Release Notes
+        # This sed command
+        # - Removes the first line of CHANGELOG.md if it contains a # character
+        # - Removes the second line if it is empty
+        # - Includes all lines of the CHANGLOG.md file until it finds a line containing the version number from the _previous_ v*.*.* tag (identified using the latest tag, which matches the release being made)
+        # >>> Note: with this method using `git describe`, all tags must be reachable from the commit tagged for the release. You can check if tags are accessible using the command `git tag --merged`
+        run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > release-notes.txt
+      - name: Release Notes Upload
+        id: release-notes-upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-notes
+          path: release-notes.txt
+          retention-days: 1

--- a/.github/workflows/generate-release-notes-v1.yml
+++ b/.github/workflows/generate-release-notes-v1.yml
@@ -7,6 +7,8 @@ jobs:
     # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
     runs-on: [custom, linux, large]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Generate Release Notes
         # This sed command
         # - Removes the first line of CHANGELOG.md if it contains a # character

--- a/.github/workflows/generate-release-notes-v1.yml
+++ b/.github/workflows/generate-release-notes-v1.yml
@@ -3,6 +3,10 @@ on:
 
 jobs:
   generate-release-notes:
+    # Reach out in #team-rel-eng to get your repositories allow-listed to use custom runners
+    # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
+    runs-on: [custom, linux, large]
+    steps:
       - name: Generate Release Notes
         # This sed command
         # - Removes the first line of CHANGELOG.md if it contains a # character

--- a/.github/workflows/generate-release-notes-v1.yml
+++ b/.github/workflows/generate-release-notes-v1.yml
@@ -8,7 +8,7 @@ jobs:
         # - Removes the first line of CHANGELOG.md if it contains a # character
         # - Removes the second line if it is empty
         # - Includes all lines of the CHANGLOG.md file until it finds a line containing the version number from the _previous_ v*.*.* tag (identified using the latest tag, which matches the release being made)
-        # >>> Note: with this method using `git describe`, all tags must be reachable from the commit tagged for the release. You can check if tags are accessible using the command `git tag --merged`
+        # >>> Note: with this method using `git describe`, all tags must be reachable from the commit tagged for the release. You can check if tags are accessible by checking out the commit you want to tag for release and then using the command `git tag --merged`
         run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > release-notes.txt
       - name: Release Notes Upload
         id: release-notes-upload

--- a/.github/workflows/generate-release-notes-v2.yml
+++ b/.github/workflows/generate-release-notes-v2.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          # Allow tag to be fetched when ref is a commit
+          fetch-depth: 0
       - name: Generate Release Notes
         # This sed command
         # - Removes the first line of CHANGELOG.md if it contains a # character

--- a/.github/workflows/generate-release-notes-v2.yml
+++ b/.github/workflows/generate-release-notes-v2.yml
@@ -1,0 +1,22 @@
+on:
+  workflow_call:
+
+jobs:
+  generate-release-notes:
+      - name: Generate Release Notes
+        # This sed command
+        # - Removes the first line of CHANGELOG.md if it contains a # character
+        # - Removes the second line if it is empty
+        # - Includes all lines of the CHANGLOG.md file until it finds a line containing the version number from the _previous_ v*.*.* tag (identified using the latest tag, which matches the release being made)
+        # >>> Note: with this method using `git tag --list`, you can tag and trigger releases from release branches, and you don't need to merge all tags into main.
+        run: |
+          export PREV_TAG=$(git tag --list 'v*' --sort=-version:refname | head -n 2 | tail -n 1)
+          export PREV_VERSION=${PREV_TAG//v}
+          sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $PREV_VERSION/q;p" CHANGELOG.md > release-notes.txt
+      - name: Release Notes Upload
+        id: release-notes-upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-notes
+          path: release-notes.txt
+          retention-days: 1

--- a/.github/workflows/generate-release-notes-v2.yml
+++ b/.github/workflows/generate-release-notes-v2.yml
@@ -7,6 +7,8 @@ jobs:
     # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
     runs-on: [custom, linux, large]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Generate Release Notes
         # This sed command
         # - Removes the first line of CHANGELOG.md if it contains a # character

--- a/.github/workflows/generate-release-notes-v2.yml
+++ b/.github/workflows/generate-release-notes-v2.yml
@@ -3,6 +3,10 @@ on:
 
 jobs:
   generate-release-notes:
+    # Reach out in #team-rel-eng to get your repositories allow-listed to use custom runners
+    # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
+    runs-on: [custom, linux, large]
+    steps:
       - name: Generate Release Notes
         # This sed command
         # - Removes the first line of CHANGELOG.md if it contains a # character


### PR DESCRIPTION
# Description

This PR is a possible solution to https://github.com/hashicorp/ghaction-terraform-provider-release/issues/23

I've taken the sed command for generating release notes from this repo's README and made it into a reusable workflow (v1). I've also produced a v2 of that workflow that uses the new version of the sed command I described in the linked issue.

I would need to update the README if this PR was accepted, but a different outcome might be avoiding making these new workflows and instead expanding the documentation about generating release notes to help users debug release note issues.

Note: I've made this PR as a draft because I expect there might be some discussion on the issue, but I'm happy for this PR to be reviewed