### PR TITLE
Support reading go version from file with `setup-go-version-file`

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -11,7 +11,11 @@ on:
         type: boolean
       setup-go-version:
         description: 'setup-go Go Version'
-        required: true
+        required: false
+        type: string
+      setup-go-version-file:
+        description: 'setup-go File From Which To Read Go Version'
+        required: false
         type: string
     secrets:
       gpg-private-key:
@@ -31,6 +35,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ inputs.setup-go-version }}
+          go-version-file: ${{ inputs.setup-go-version-file }}
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -21,7 +21,11 @@ on:
         type: number
       setup-go-version:
         description: 'setup-go Go Version'
-        required: true
+        required: false
+        type: string
+      setup-go-version-file:
+        description: 'setup-go File From Which To Read Go Version'
+        required: false
         type: string
       signore-signer:
         description: 'signore Signer'
@@ -77,6 +81,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ inputs.setup-go-version }}
+          go-version-file: ${{ inputs.setup-go-version-file }}
       # See also: ENGSRV-063: setup-hc-releases GitHub Action
       -
         name: Setup hc-releases


### PR DESCRIPTION
Using the `go-version-file` argument added in https://github.com/actions/setup-go/pull/62#event-6596057613

Please note I have not yet tested this end-to-end, I am assuming the desired behavior will occur when `setup-go-version` is empty and opening this PR in case someone else wants to test it first.

If it works, I'll add a block to the README too.