### PR TITLE
Add a git-ref parameter to specify checkout git reference

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -29,11 +29,6 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - if: inputs.git-ref == ''
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - if: inputs.git-ref != ''
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git-ref }}

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -29,7 +29,7 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.git-ref }}
           fetch-depth: 0

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -13,6 +13,10 @@ on:
         description: 'setup-go Go Version'
         required: true
         type: string
+      git-ref:
+        description: 'branch, tag or SHA to checkout'
+        required: false
+        type: string
     secrets:
       gpg-private-key:
         description: 'GPG Private Key'
@@ -25,8 +29,14 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - if: inputs.git-ref == ''
+        uses: actions/checkout@v3
         with:
+          fetch-depth: 0
+      - if: inputs.git-ref != ''
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-ref }}
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -32,6 +32,10 @@ on:
         description: 'Product Version (e.g. v1.2.3 or github.ref_name)'
         required: true
         type: string
+      git-ref:
+        description: 'branch, tag or SHA to checkout'
+        required: false
+        type: string
 
     secrets:
       hc-releases-github-token:
@@ -70,9 +74,15 @@ jobs:
     # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
     runs-on: [custom, linux, large]
     steps:
-      - uses: actions/checkout@v3
+      - if: inputs.git-ref == ''
+        uses: actions/checkout@v3
         with:
           # Allow tag to be fetched when ref is a commit
+          fetch-depth: 0
+      - if: inputs.git-ref != ''
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-ref }}
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -32,10 +32,6 @@ on:
         description: 'Product Version (e.g. v1.2.3 or github.ref_name)'
         required: true
         type: string
-      git-ref:
-        description: 'branch, tag or SHA to checkout'
-        required: false
-        type: string
 
     secrets:
       hc-releases-github-token:
@@ -74,15 +70,10 @@ jobs:
     # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
     runs-on: [custom, linux, large]
     steps:
-      - if: inputs.git-ref == ''
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.product-version }}
           # Allow tag to be fetched when ref is a commit
-          fetch-depth: 0
-      - if: inputs.git-ref != ''
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.git-ref }}
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
What?
This changes adds an optional git-ref parameter to both the Community and Hashicorp versions of the action. This allows users to optionally specify a specific branch, tag or SHA to checkout when using the Checkout Github Action. If this parameter is not used then the default behavior of using the reference or SHA that triggered the event or the default branch will be used.

Why?
This parameter is useful for release workflows that push changes to the repository and want to use this action in the same workflow. Since the default behavior is using the reference or SHA that triggered the workflow, if there is a change made to the remote during the workflow, it will not be captured during the checkout in this release action.