### PR TITLE
remove-dependabot-github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Removing dependabot github actions in preparation for TSCCR automation.