### PR TITLE
Prepare v3 major release

### DIFF
--- a/.changes/unreleased/BREAKING CHANGES-20240118-164436.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-20240118-164436.yaml
@@ -1,0 +1,7 @@
+kind: BREAKING CHANGES
+body: 'all: Workflows are now using `actions/download-artifact@v4` which is compatible
+  with `actions/upload-artifact@v3`. Calling workflows must be upgraded to
+  `actions/upload-artifact@v4` when including release notes'
+time: 2024-01-18T16:44:36.091732-05:00
+custom:
+  Issue: "76"

--- a/.changes/unreleased/BREAKING CHANGES-20240118-164436.yaml
+++ b/.changes/unreleased/BREAKING CHANGES-20240118-164436.yaml
@@ -1,5 +1,5 @@
 kind: BREAKING CHANGES
-body: 'all: Workflows are now using `actions/download-artifact@v4` which is compatible
+body: 'all: Workflows are now using `actions/download-artifact@v4` which is incompatible
   with `actions/upload-artifact@v3`. Calling workflows must be upgraded to
   `actions/upload-artifact@v4` when including release notes'
 time: 2024-01-18T16:44:36.091732-05:00

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -43,7 +43,7 @@ jobs:
           go-version-file: ${{ inputs.setup-go-version-file }}
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
         with:
           gpg_private_key: ${{ secrets.gpg-private-key }}
           passphrase: ${{ secrets.gpg-private-key-passphrase }}
@@ -58,7 +58,7 @@ jobs:
       - if: inputs.release-notes
         id: release-notes-download
         name: Release Notes Download
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           name: release-notes
           path: /tmp

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -106,7 +106,7 @@ jobs:
       - if: inputs.release-notes
         id: release-notes-download
         name: Release Notes Download
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
         with:
           name: release-notes
           path: /tmp

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
   # ... potentially other jobs ...
   terraform-provider-release:
     name: 'Terraform Provider Release'
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v2
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v3
     secrets:
       gpg-private-key: '${{ secrets.GPG_PRIVATE_KEY }}'
     with:
@@ -49,7 +49,7 @@ jobs:
   # ... potentially other jobs ...
   terraform-provider-release:
     name: 'Terraform Provider Release'
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v2
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@v3
     secrets:
 
       hc-releases-github-token: '${{ secrets.HASHI_RELEASES_GITHUB_TOKEN }}'
@@ -82,12 +82,12 @@ jobs:
   release-notes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Generate Release Notes
         run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > release-notes.txt
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: release-notes
           path: release-notes.txt
@@ -102,7 +102,7 @@ jobs:
   terraform-provider-release:
     name: 'Terraform Provider Release'
     needs: [release-notes]
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v2
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v3
     secrets:
       gpg-private-key: '${{ secrets.GPG_PRIVATE_KEY }}'
     with:


### PR DESCRIPTION
Closes #76
Closes #77

GitHub has released `actions/upload-artifact` and `actions/download-artifact` v4 major version updates which are both incompatible with v3 of each. Since the reusable workflows are dependent on the calling workflow uploading the artifact, updating these workflows to `actions/download-artifact@v4` would break any callers using `actions/upload-artifact@v3`.