### PR TITLE
Use single label for github runner

### DIFF
--- a/.changes/unreleased/NOTES-20240516-153226.yaml
+++ b/.changes/unreleased/NOTES-20240516-153226.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: 'hashicorp: Adjusted self-hosted runner label to new equivalent to prevent workflow errors after May 27th, 2024'
+time: 2024-05-16T15:32:26.829079-04:00
+custom:
+    Issue: "93"

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,4 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
-    - custom
-    - large
+    - custom-linux-large

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -72,7 +72,7 @@ jobs:
   Release:
     # Reach out in #team-rel-eng to get your repositories allow-listed to use custom runners
     # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
-    runs-on: [custom, linux, large]
+    runs-on: custom-linux-large
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:


### PR DESCRIPTION
👋 Greetings! 

To align with Github’s removal of [custom labels on larger runners](https://github.blog/changelog/2023-02-15-github-actions-removal-of-additional-label-option-for-github-hosted-larger-runners/), this PR is updating the labels defined in your Github Action jobs. Moving forward, only one label (the name of GH runner type)  will be needed to ensure an appropriate runner is used for your GHA job.

Please review for accuracy and merge before May 27, 2024. Thank you!

