### PR TITLE
update runner to use 22.04

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,4 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
     - custom-linux-large
+    - custom-ubuntu-22.04-x64-16core

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -72,7 +72,7 @@ jobs:
   Release:
     # Reach out in #team-rel-eng to get your repositories allow-listed to use custom runners
     # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
-    runs-on: custom-linux-large
+    runs-on: custom-ubuntu-22.04-x64-16core
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
this addresses issues that come from latest changes in actions: https://github.com/actions/runner-images/issues/11101