### PR TITLE
Prepare `5.1.0` release

### DIFF
--- a/.changes/unreleased/NOTES-20250414-153308.yaml
+++ b/.changes/unreleased/NOTES-20250414-153308.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: 'hashicorp: update custom runner label due to GitHub Actions deprecation of Ubuntu 20.04'
+time: 2025-04-14T15:33:08.666376-04:00
+custom:
+    Issue: "117"

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,4 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
-    - custom-linux-large
     - custom-ubuntu-22.04-x64-16core

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
+# https://github.com/rhysd/actionlint/blob/HEAD/docs/config.md
 self-hosted-runner:
-  # Labels of self-hosted runner in array of string
   labels:
-    - custom-ubuntu-22.04-x64-16core
+    - custom-ubuntu-22.04-large

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -70,9 +70,8 @@ on:
 
 jobs:
   Release:
-    # Reach out in #team-rel-eng to get your repositories allow-listed to use custom runners
-    # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
-    runs-on: custom-ubuntu-22.04-x64-16core
+    # Reach out in #team-pss to get your repositories allow-listed to use custom runners
+    runs-on: custom-ubuntu-22.04-large
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Previously: #114 

This PR prepares a `5.1.0` release. This will release today so that the workflow continues to work after the April 15 total deprecation of Ubuntu 20.04 runners.

Rollout:

* Merge this PR
* Run this repo's Release workflow with input: `v5.1.0`
  * I expect that the Release workflow will [create the `v5.1.0` tag and will update the `v5` floating tag](https://github.com/hashicorp/ghaction-terraform-provider-release/blob/971304fabf3bb4253f795c7a1c1ff4792823b469/.github/workflows/release.yml#L84-L87)

Further, there are (11) official providers that use the `v4.0.1` or `v4` versions of this workflow. For a minimum impact change, I feel it's best to backport #114 to a `release/4.0.x` branch and then release `v4.1.0`. In this way, providers would not be faced with a `v5` upgrade on a short timeline.

