### PR TITLE
hashicorp: update `runs-on`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,7 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
     - custom-linux-large
+    - custom-ubuntu-22.04-small
+    - custom-ubuntu-22.04-medium
+    - custom-ubuntu-22.04-large
+    - custom-ubuntu-22.04-xl

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -124,7 +124,7 @@ jobs:
           SIGNORE_SIGNER: ${{ inputs.signore-signer }}
       -
         name: Create Release metadata
-        uses: hashicorp/actions-hc-releases-create-metadata@55b4c082ae041fe03831520bab4fc475e54b635b # debug
+        uses: hashicorp/actions-hc-releases-create-metadata@0e93868399ba972826b3e12b56915bee475955a3 # v2
         with:
           private-tools-token: ${{ secrets.hc-releases-github-token }}
           product-name: ${{ github.event.repository.name }}

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -130,3 +130,13 @@ jobs:
           version: ${{ inputs.product-version }}
           hc-releases-host: ${{ secrets.hc-releases-host-staging }}
           hc-releases-key: ${{ secrets.hc-releases-key-staging }}
+      -
+        name: Promote
+        uses: hashicorp/actions-hc-releases-promote@811b5f3b44787dbb5c3aa21d3fe8a4e844eb41ed # v1.0.0
+        with:
+          product-name: ${{ github.event.repository.name }}
+          version: ${{ inputs.product-version }}
+          hc-releases-host: ${{ secrets.hc-releases-host-prod }}
+          hc-releases-key: ${{ secrets.hc-releases-key-prod }}
+          hc-releases-source_env_key: ${{ secrets.hc-releases-key-staging }}
+          hc-releases-terraform-registry-sync-token: ${{ secrets.hc-releases-terraform-registry-sync-token }}

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -134,7 +134,7 @@ jobs:
           SIGNORE_SIGNER: ${{ inputs.signore-signer }}
       -
         name: Create Release metadata
-        uses: hashicorp/actions-hc-releases-create-metadata@0e93868399ba972826b3e12b56915bee475955a3 # v2
+        uses: hashicorp/actions-hc-releases-create-metadata@55b4c082ae041fe03831520bab4fc475e54b635b # debug
         with:
           private-tools-token: ${{ secrets.hc-releases-github-token }}
           product-name: ${{ github.event.repository.name }}

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -36,16 +36,6 @@ on:
         description: 'Product Version (e.g. v1.2.3 or github.ref_name if already the tag name)'
         required: true
         type: string
-      changelog:
-        description: 'Add changelog URL to the release metadata'
-        required: false
-        default: true
-        type: boolean
-      promote:
-        description: 'Promote to production'
-        required: false
-        default: true
-        type: boolean
 
     secrets:
       hc-releases-github-token:
@@ -138,14 +128,12 @@ jobs:
         with:
           private-tools-token: ${{ secrets.hc-releases-github-token }}
           product-name: ${{ github.event.repository.name }}
-          changelog: ${{ inputs.changelog }}
           version: ${{ inputs.product-version }}
           hc-releases-host: ${{ secrets.hc-releases-host-staging }}
           hc-releases-key: ${{ secrets.hc-releases-key-staging }}
       -
         name: Promote
         uses: hashicorp/actions-hc-releases-promote@811b5f3b44787dbb5c3aa21d3fe8a4e844eb41ed # v1.0.0
-        if: inputs.promote == true
         with:
           product-name: ${{ github.event.repository.name }}
           version: ${{ inputs.product-version }}

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -39,12 +39,12 @@ on:
       changelog:
         description: 'Add changelog URL to the release metadata'
         required: false
-        default: 'true'
+        default: true
         type: boolean
       promote:
         description: 'Promote to production'
         required: false
-        default: 'true'
+        default: true
         type: boolean
 
     secrets:

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -70,7 +70,7 @@ on:
 
 jobs:
   Release:
-    runs-on: ubuntu-latest
+    runs-on: custom-ubuntu-22.04-large
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -36,6 +36,10 @@ on:
         description: 'Product Version (e.g. v1.2.3 or github.ref_name if already the tag name)'
         required: true
         type: string
+      changelog:
+        description: 'Add changelog URL to the release metadata'
+        required: false
+        default: 'true'
 
     secrets:
       hc-releases-github-token:
@@ -128,6 +132,7 @@ jobs:
         with:
           private-tools-token: ${{ secrets.hc-releases-github-token }}
           product-name: ${{ github.event.repository.name }}
+          changelog: ${{ inputs.changelog }}
           version: ${{ inputs.product-version }}
           hc-releases-host: ${{ secrets.hc-releases-host-staging }}
           hc-releases-key: ${{ secrets.hc-releases-key-staging }}

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -132,13 +132,3 @@ jobs:
           version: ${{ inputs.product-version }}
           hc-releases-host: ${{ secrets.hc-releases-host-staging }}
           hc-releases-key: ${{ secrets.hc-releases-key-staging }}
-      -
-        name: Promote
-        uses: hashicorp/actions-hc-releases-promote@811b5f3b44787dbb5c3aa21d3fe8a4e844eb41ed # v1.0.0
-        with:
-          product-name: ${{ github.event.repository.name }}
-          version: ${{ inputs.product-version }}
-          hc-releases-host: ${{ secrets.hc-releases-host-prod }}
-          hc-releases-key: ${{ secrets.hc-releases-key-prod }}
-          hc-releases-source_env_key: ${{ secrets.hc-releases-key-staging }}
-          hc-releases-terraform-registry-sync-token: ${{ secrets.hc-releases-terraform-registry-sync-token }}

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -40,6 +40,12 @@ on:
         description: 'Add changelog URL to the release metadata'
         required: false
         default: 'true'
+        type: boolean
+      promote:
+        description: 'Promote to production'
+        required: false
+        default: 'true'
+        type: boolean
 
     secrets:
       hc-releases-github-token:
@@ -139,6 +145,7 @@ jobs:
       -
         name: Promote
         uses: hashicorp/actions-hc-releases-promote@811b5f3b44787dbb5c3aa21d3fe8a4e844eb41ed # v1.0.0
+        if: inputs.promote == true
         with:
           product-name: ${{ github.event.repository.name }}
           version: ${{ inputs.product-version }}

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -70,9 +70,7 @@ on:
 
 jobs:
   Release:
-    # Reach out in #team-rel-eng to get your repositories allow-listed to use custom runners
-    # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
-    runs-on: custom-linux-large
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -70,6 +70,7 @@ on:
 
 jobs:
   Release:
+    # Reach out in #team-stride to get your repositories allow-listed to use custom runners
     runs-on: custom-ubuntu-22.04-large
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 HashiCorp, Inc.
+Copyright IBM Corp. 2021, 2026
 
 Mozilla Public License, version 2.0
 


### PR DESCRIPTION
## Description

By trial and error, we've observed that legacy runner labels are not shared to newly-minted provider repo.

This change updates the 4.x series to use an available runner label.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
