### PR TITLE
hashicorp: update `runs-on`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,7 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
     - custom-linux-large
+    - custom-ubuntu-22.04-small
+    - custom-ubuntu-22.04-medium
+    - custom-ubuntu-22.04-large
+    - custom-ubuntu-22.04-xl

--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -70,9 +70,8 @@ on:
 
 jobs:
   Release:
-    # Reach out in #team-rel-eng to get your repositories allow-listed to use custom runners
-    # Custom runners range in size from 4 core to 64 core and sizes `small` through `xl` are supported
-    runs-on: custom-linux-large
+    # Reach out in #team-stride to get your repositories allow-listed to use custom runners
+    runs-on: custom-ubuntu-22.04-large
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 HashiCorp, Inc.
+Copyright IBM Corp. 2021, 2026
 
 Mozilla Public License, version 2.0
 


### PR DESCRIPTION
## Description

Applies these changes to the `release/v4` branch:

* Use new label for custom large runner
* Update LICENSE
* Update actionlint

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

None.