### PR TITLE
Update setup-signore action to version 4.0.0

### DIFF
--- a/.github/workflows/hashicorp.yml
+++ b/.github/workflows/hashicorp.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           github-token: ${{ secrets.hc-releases-github-token }}
       # See also: ENGSRV-065: setup-signore GitHub Action
-      - uses: hashicorp/setup-signore@d64bb29059259ffcbdc4c7066cdb296e45e828b3 # v3.0.0
+      - uses: hashicorp/setup-signore@10fc85993bdc9e07ecfa195b926991a366dfc67c # v4.0.0
         with:
           github-token: ${{ secrets.setup-signore-github-token }}
       - if: inputs.release-notes != true


### PR DESCRIPTION
PR is necessary in order to resolve the nodejs20 depedency error, the bump was introduced in the latest release of [setup-signore](https://github.com/hashicorp/setup-signore/pull/132)